### PR TITLE
Added feature to create another pom file in which we set the kafka version properties

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -52,31 +52,26 @@
             <groupId>org.apache.maven</groupId>
             <artifactId>maven-model</artifactId>
             <version>${mavenVersion}</version>
-            <scope>provided</scope>
         </dependency>
         <dependency>
             <groupId>org.apache.maven</groupId>
             <artifactId>maven-core</artifactId>
             <version>${mavenVersion}</version>
-            <scope>provided</scope>
         </dependency>
         <dependency>
             <groupId>org.apache.maven</groupId>
             <artifactId>maven-plugin-api</artifactId>
             <version>${mavenVersion}</version>
-            <scope>provided</scope>
         </dependency>
         <dependency>
             <groupId>org.apache.maven</groupId>
             <artifactId>maven-artifact</artifactId>
             <version>${mavenVersion}</version>
-            <scope>provided</scope>
         </dependency>
         <dependency>
             <groupId>org.apache.maven.plugin-tools</groupId>
             <artifactId>maven-plugin-annotations</artifactId>
             <version>3.4</version>
-            <scope>provided</scope>
         </dependency>
         <dependency>
             <groupId>junit</groupId>
@@ -84,7 +79,12 @@
             <version>4.13</version>
             <scope>test</scope>
         </dependency>
-
+        <dependency>
+          <groupId>org.codehaus.mojo</groupId>
+          <artifactId>versions-maven-plugin</artifactId>
+          <version>2.7</version>
+          <type>maven-plugin</type>
+        </dependency>
     </dependencies>
 
     <build>


### PR DESCRIPTION
I added a new feature to this plugin which runs after we resolve the version ranges for kafka and ce-kakfa. This plugin is now only meant to be run from the common-parent project. This will load up the common-parent pom file with out doing any replacements and processing which maven normally does and which is why we can't just use the project object to get the contents. Then we replace the current values for the two kafka version properties with the versions we just resolved as being the latest versions. Then we write out this new pom file to the system, default file is installed_pom.xml

After this is released the common-parent pom will be modified in two ways. One, it will configure this plugin to not be inherited so that it only runs once for the common-parent project and not during any of the child or inherited projects. Two, an extra call to the install plugin will be added so that the pom file produced from this plugin is installed in the maven repo. That way the pom file which gets installed in the repo will have the kafka version properties set to the latest version and when ever a project inherits from common it will not need to resolve the version ranges for kafka because the versions will already be set.