### PR TITLE
Do not write the installed pom file by default, and only if a file name is provided

### DIFF
--- a/src/main/java/io/confluent/maven/resolver/ResolveKafkaVersionRangeMojo.java
+++ b/src/main/java/io/confluent/maven/resolver/ResolveKafkaVersionRangeMojo.java
@@ -124,7 +124,7 @@ public class ResolveKafkaVersionRangeMojo extends AbstractMojo {
 	/**
 	 * The name of the new pom file to create.
 	 */
-	@Parameter(property = "resolver.new.pom.file", defaultValue = "installed_pom.xml")
+	@Parameter(property = "resolver.new.pom.file")
 	private String newPomFile;
 
 	/**
@@ -186,7 +186,9 @@ public class ResolveKafkaVersionRangeMojo extends AbstractMojo {
 					project.getProperties().put(CCS_KAFKA_VERSION, highestCCSVersion.toString());
 				}
 
-				createInstallPom(highestCEVersion.toString(), highestCCSVersion.toString());
+        if (newPomFile != null) {
+				  createInstalledPom(highestCEVersion.toString(), highestCCSVersion.toString());
+        }
 			} catch (VersionRangeResolutionException e) {
 				throw new MojoExecutionException("", e);
 			}
@@ -269,7 +271,7 @@ public class ResolveKafkaVersionRangeMojo extends AbstractMojo {
    * @param ccsVersion The version of CCS Kafka
    * @throws MojoExecutionException If there is a failure creating the pom file or setting the properties
    */
-  public void createInstallPom(String ceVersion, String ccsVersion) throws MojoExecutionException
+  public void createInstalledPom(String ceVersion, String ccsVersion) throws MojoExecutionException
   {
     try {
       getLog().info("Creating installed pom file");


### PR DESCRIPTION
When running the resolver plugin from the command line it is creating the installed pom file, but we don't want that to happen by default. Usually when running the resolver plugin from the command line we are going to take the returned values and then use them to modify the existing pom file, so we don't need it to create the installed pom file. If it does create the installed pom file in that case it can cause an issue because we are usually running from our ci scripts and we don't want to commit that file by accident. It also causes an issue in the packaging builds for debian because we can't have any uncommitted files laying around or it fails.

I also renamed the method for creating the installed pom file because it didn't match up with everything else related to that function.