### PR TITLE
Fix bug in new pom file property

### DIFF
--- a/src/main/java/io/confluent/maven/resolver/ResolveKafkaVersionRangeMojo.java
+++ b/src/main/java/io/confluent/maven/resolver/ResolveKafkaVersionRangeMojo.java
@@ -124,7 +124,7 @@ public class ResolveKafkaVersionRangeMojo extends AbstractMojo {
 	/**
 	 * The name of the new pom file to create.
 	 */
-	@Parameter(property = "resolver.new.pom.file")
+	@Parameter(property = "resolver.newPomFile")
 	private String newPomFile;
 
 	/**


### PR DESCRIPTION
The property name being used for the new pom file was not valid. This fixes that issue. I tested it by using it locally to build common repo and added debug print statements to print out the value. I confirmed that when provided the file name is present. If not provided the value is null and creating the new pom file is skipped. I will also need to update the common pom to use this new property name.