### PR TITLE
Add parameter to enable releasing to maven central

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -53,6 +53,7 @@ node('docker-oraclejdk8') {
                   } else {
                       // it's a parameterized job, and we should deploy to maven central.
                       sh '''
+                          set +x
                           gpg --import < $GPG_PRIVATE_KEY;
                           mvn --batch-mode clean deploy -P maven-central -Dgpg.passphrase=$GPG_PASSPHRASE
                       '''

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -28,7 +28,7 @@ node('docker-oraclejdk8') {
                         returnStdout: true
                         ).trim()
 
-        if ( !params.RELEASE_TAG.trim().equals("v" + project_version.trim()) ){
+        if ( !params.RELEASE_TAG.trim().equals(project_version) ){
             echo 'ERROR: tag doesn\'t match project version, please correct and try again'
             echo "Tag: ${params.RELEASE_TAG}"
             echo "Project version: ${project_version}"

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -9,6 +9,7 @@ def RelaseTag = string(name: 'RELEASE_TAG', defaultValue: '',
 def config = jobConfig {
     owner = 'tools'
     slackChannel = 'tools-notifications'
+    nodeLabel = 'docker-oraclejdk8'
     usesDockerForTesting = false
     runMergeCheck = false
     testResultSpecs = ['junit': 'test/results.xml']

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -1,8 +1,65 @@
 #!/usr/bin/env groovy
 
-common {
-    slackChannel = '#tools-notifications'
-    downStreamValidate = false
-    runMergeCheck = false
-    nodeLabel = 'docker-oraclejdk8'
+// Copyright 2020 Confluent Inc
+
+properties([
+        buildDiscarder(logRotator(artifactDaysToKeepStr: '', artifactNumToKeepStr: '', daysToKeepStr: '30', numToKeepStr: '')),
+        parameters([
+            string(name: 'RELEASE_TAG', defaultValue: '')
+        ])
+])
+
+// We use the oldest available jdk version.
+node('docker-oraclejdk8') {
+  stage('Source') {
+    checkout([
+        $class: 'GitSCM',
+        branches: scm.branches,
+        doGenerateSubmoduleConfigurations: scm.doGenerateSubmoduleConfigurations,
+        extensions: [[$class: 'CloneOption', noTags: false, shallow: false, depth: 0, reference: '']],
+        userRemoteConfigs: scm.userRemoteConfigs,
+    ])
+
+    // If we have a RELEASE_TAG specified as a build parameter, test that the version in pom.xml matches the tag.
+    if ( !params.RELEASE_TAG.trim().equals('') ) {
+        sh "git checkout ${params.RELEASE_TAG}"
+        def project_version = sh (
+                        script: 'mvn help:evaluate -Dexpression=project.version -q -DforceStdout | tail -1',
+                        returnStdout: true
+                        ).trim()
+
+        if ( !params.RELEASE_TAG.trim().equals("v" + project_version.trim()) ){
+            echo 'ERROR: tag doesn\'t match project version, please correct and try again'
+            echo "Tag: ${params.RELEASE_TAG}"
+            echo "Project version: ${project_version}"
+            currentBuild.result = 'FAILURE'
+            return
+        }
+    }
+  }
+  stage('Build') {
+      archiveArtifacts artifacts: 'pom.xml'
+      withVaultEnv([["artifactory/tools_jenkins", "user", "TOOLS_ARTIFACTORY_USER"],
+          ["artifactory/tools_jenkins", "password", "TOOLS_ARTIFACTORY_PASSWORD"],
+          ["sonatype/confluent", "user", "SONATYPE_OSSRH_USER"],
+          ["sonatype/confluent", "password", "SONATYPE_OSSRH_PASSWORD"],
+          ["gpg/packaging", "passphrase", "GPG_PASSPHRASE"]]) {
+          withVaultFile([["maven/jenkins_maven_global_settings", "settings_xml", "maven-global-settings.xml", "MAVEN_GLOBAL_SETTINGS_FILE"],
+              ["gpg/packaging", "private_key", "confluent-packaging-private.key", "GPG_PRIVATE_KEY"]]) {
+              withMaven(globalMavenSettingsFilePath: "${env.MAVEN_GLOBAL_SETTINGS_FILE}") {
+
+                  if ( params.RELEASE_TAG.trim().equals('') ) {
+                      sh "mvn --batch-mode -Pjenkins clean verify install dependency:analyze site validate -U"
+                  } else {
+                      // it's a parameterized job, and we should deploy to maven central.
+                      sh '''
+                          gpg --import < $GPG_PRIVATE_KEY;
+                          mvn --batch-mode clean deploy -P maven-central -Dgpg.passphrase=$GPG_PASSPHRASE
+                      '''
+                  }
+                  currentBuild.result = 'Success'
+              }
+          }
+      }
+  }
 }

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -39,9 +39,7 @@ node('docker-oraclejdk8') {
   }
   stage('Build') {
       archiveArtifacts artifacts: 'pom.xml'
-      withVaultEnv([["artifactory/tools_jenkins", "user", "TOOLS_ARTIFACTORY_USER"],
-          ["artifactory/tools_jenkins", "password", "TOOLS_ARTIFACTORY_PASSWORD"],
-          ["sonatype/confluent", "user", "SONATYPE_OSSRH_USER"],
+      withVaultEnv([["sonatype/confluent", "user", "SONATYPE_OSSRH_USER"],
           ["sonatype/confluent", "password", "SONATYPE_OSSRH_PASSWORD"],
           ["gpg/packaging", "passphrase", "GPG_PASSPHRASE"]]) {
           withVaultFile([["maven/jenkins_maven_global_settings", "settings_xml", "maven-global-settings.xml", "MAVEN_GLOBAL_SETTINGS_FILE"],

--- a/Readme.md
+++ b/Readme.md
@@ -38,6 +38,12 @@ This example writes the matching version number into the property `latestMavenMo
         </executions>
     </plugin>
 
+Manual release
+-------------------
+1. Use mvn release:prepare to cut new version tags
+2. Create branch based on version tag
+3. Use release parameter to release to maven central
+
 System requirements
 -------------------
 

--- a/pom.xml
+++ b/pom.xml
@@ -418,5 +418,54 @@
                 </plugins>
             </build>
         </profile>
+        <profile>
+            <id>maven-central</id>
+            <properties>
+            <tools.jar>${java.home}/../lib/tools.jar</tools.jar>
+            <m2_repo>${user.home}/.m2/repository</m2_repo>
+            <ntdll_target>build</ntdll_target>
+            </properties>
+            <activation>
+                <property>
+                    <name>performRelease</name>
+                    <value>true</value>
+                </property>
+            </activation>
+            <distributionManagement>
+                <snapshotRepository>
+                    <id>ossrh</id>
+                    <url>https://oss.sonatype.org/content/repositories/snapshots</url>
+                </snapshotRepository>
+            </distributionManagement>
+            <build>
+                <plugins>
+                    <plugin>
+                        <groupId>org.apache.maven.plugins</groupId>
+                        <artifactId>maven-gpg-plugin</artifactId>
+                        <version>1.5</version>
+                        <executions>
+                            <execution>
+                                <id>sign-artifacts</id>
+                                <phase>verify</phase>
+                                <goals>
+                                    <goal>sign</goal>
+                                </goals>
+                            </execution>
+                        </executions>
+                    </plugin>
+                    <plugin>
+                        <groupId>org.sonatype.plugins</groupId>
+                        <artifactId>nexus-staging-maven-plugin</artifactId>
+                        <version>1.6.7</version>
+                        <extensions>true</extensions>
+                        <configuration>
+                            <serverId>ossrh</serverId>
+                            <nexusUrl>https://oss.sonatype.org/</nexusUrl>
+                            <autoReleaseAfterClose>true</autoReleaseAfterClose>
+                        </configuration>
+                    </plugin>
+                </plugins>
+            </build>
+        </profile>
     </profiles>
 </project>

--- a/pom.xml
+++ b/pom.xml
@@ -420,11 +420,6 @@
         </profile>
         <profile>
             <id>maven-central</id>
-            <properties>
-            <tools.jar>${java.home}/../lib/tools.jar</tools.jar>
-            <m2_repo>${user.home}/.m2/repository</m2_repo>
-            <ntdll_target>build</ntdll_target>
-            </properties>
             <activation>
                 <property>
                     <name>performRelease</name>


### PR DESCRIPTION
# what
We need to release this plugin to maven central for community build use case.

# how
Add maven-central profile and add `RELEASE_TAG` parameter to enable it.

# test
Have not tested it since, it will need to be run on a release branch, but I follow the same pattern as https://github.com/confluentinc/confluent-log4j/blob/master/Jenkinsfile 