### PR TITLE
Add options to not fail if no artifacts were found

### DIFF
--- a/src/test/java/io/confluent/maven/resolver/KafkaFetchTest.java
+++ b/src/test/java/io/confluent/maven/resolver/KafkaFetchTest.java
@@ -26,7 +26,7 @@ public class KafkaFetchTest {
         Version VTWELVE_CE = genericVersionScheme.parseVersion(TWELVE_CE);
         Test.addVersion(VTWELVE_CE);
         Test.addVersion(VONE_CCS);
-        Version result = resolve.fetchHighestKafkaVersion(CCS, Test , constrainText);
-        assertEquals(VONE_CCS, result);
+        String result = resolve.fetchHighestKafkaVersion(CCS, Test , constrainText, false);
+        assertEquals(ONE_CCS, result);
     }
 }


### PR DESCRIPTION
Problem:
When the open source community is building the common project they don't have access to ce-kafka artifacts so this resolver fails to find any versions of artifacts when trying to resolve the version range.

Solution:
This change adds options to not fail the build if the resolver plugin can not find ce/ccs artifacts. Using these options in the common pom we can set it to not fail if ce-kafka artifacts are not found when resolving the version range, and to fail if ccs kafka artifacts are found. During our internal CI builds we can override this and set it to fail if ce-kafka artifacts are not found as well.

One change I needed to make was to return a string when resolving the version range instead of returning a Version object because if we don't find the version for an artifact I set the value to "not found" so that when some one looks through the logs or at a pom they will be able to tell that it did not find an artifact version.

I also did some other minor cleanup. 