### PR TITLE
skip when verion range is not valid

### DIFF
--- a/src/it/it-resolve-kafka-range-test-003/invoker.properties
+++ b/src/it/it-resolve-kafka-range-test-003/invoker.properties
@@ -1,0 +1,1 @@
+invoker.goals=${project.groupId}:${project.artifactId}:${project.version}:resolve-kafka-range

--- a/src/it/it-resolve-kafka-range-test-003/pom.xml
+++ b/src/it/it-resolve-kafka-range-test-003/pom.xml
@@ -1,0 +1,52 @@
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+  <modelVersion>4.0.0</modelVersion>
+
+  <groupId>localhost</groupId>
+  <artifactId>it-lex-order-test-001</artifactId>
+  <version>1.0</version>
+  <packaging>pom</packaging>
+  <name>Update a dependency to the latest version</name>
+  <description>
+    This is a simple IT test to test that maven ce ccs kafka version compare do not
+    follow lexi order.
+  </description>
+
+  <dependencies>
+    <dependency>
+      <groupId>localhost</groupId>
+      <artifactId>kafka-clients</artifactId>
+      <version>${ce.kafka.version}</version>
+    </dependency>
+  </dependencies>
+
+    <properties>
+        <ce.kafka.version>6.1.0-ccs</ce.kafka.version>
+        <kafka.version>6.1.0-ce</kafka.version>
+    </properties>
+    
+  <build>
+    <plugins>
+      <plugin>
+        <groupId>@project.groupId@</groupId>
+        <artifactId>@project.artifactId@</artifactId>
+        <version>@project.version@</version>
+        <configuration>
+            <groupId>localhost</groupId>
+            <artifactId>kafka-clients</artifactId>
+            <versionRange>6.1.0</versionRange>
+            <skip>true</skip>
+        </configuration>
+        <executions>
+            <execution>
+            <phase>validate</phase>
+                <goals>
+                    <goal>resolve-kafka-range</goal>
+                </goals>
+            </execution>
+        </executions>
+      </plugin>
+    </plugins>
+  </build>
+
+</project>

--- a/src/it/it-resolve-kafka-range-test-003/verify.groovy
+++ b/src/it/it-resolve-kafka-range-test-003/verify.groovy
@@ -1,0 +1,5 @@
+def buildLog = new File( basedir, "build.log")
+
+assert buildLog.text.contains( '[INFO] Skip version range resolve since property is not a valid range' )
+
+return true

--- a/src/main/java/io/confluent/maven/resolver/ResolveKafkaVersionRangeMojo.java
+++ b/src/main/java/io/confluent/maven/resolver/ResolveKafkaVersionRangeMojo.java
@@ -159,6 +159,10 @@ public class ResolveKafkaVersionRangeMojo extends AbstractMojo {
 
 	@Override
 	public void execute() throws MojoExecutionException, MojoFailureException {
+        if (!isVersionRange(versionRange)) {
+            skip = true;
+            getLog().info("Skip version range resolve since property is not a valid range");
+        }
 		if(!skip) {
 			VersionRangeRequest request = new VersionRangeRequest();
 			request.setRepositories(remoteRepositories);
@@ -386,5 +390,12 @@ public class ResolveKafkaVersionRangeMojo extends AbstractMojo {
 
 	private static boolean isCE(String version) {
 		return version.endsWith(Strings.CE_QUALIFIER.toString());
-	}
+    }
+    
+    private static boolean isVersionRange(String versionRange) {
+        boolean startValid = versionRange.startsWith("[") || versionRange.startsWith("(");
+        boolean endValid = versionRange.endsWith("]") || versionRange.endsWith(")");
+        return startValid && endValid;
+    }
+
 }


### PR DESCRIPTION
# what
Related to https://github.com/confluentinc/common/issues/317, skip version range resolve process when the version range is not valid.

Clean some code lint format.

# how
Add `isVersionRange` and skip reversion range resolve when the versionRange is not valid.