### PR TITLE
Change ownership to devprod team

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,2 +1,1 @@
-# See go/codeowners - automatically generated for confluentinc/resolver-maven-plugin:
-*	@xli1996
+*	@confluentinc/devprod


### PR DESCRIPTION
This changes the ownership of the repo to `@confluentinc/devprod`.