### PR TITLE
DP-7231: Rename DevProd to builds-automations-and-repositories in CODEOWNERS

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,1 +1,1 @@
-*	@confluentinc/devprod
+*	@confluentinc/builds-automations-and-repositories


### PR DESCRIPTION
The GitHub team `builds-automations-and-repositories` used to be named `DevProd`.

This PR updates the CODEOWNERS file to reflect the new team name.